### PR TITLE
Fcc 15 register user

### DIFF
--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -7,7 +7,6 @@ from resources.request_for_data import RequestForData
 from resources.register import Register
 from db import db
 from flask_cors import CORS
-from flask_bcrypt import Bcrypt
 
 def create_app(**config_overrides):
     app = Flask(__name__)
@@ -15,9 +14,6 @@ def create_app(**config_overrides):
     app.config.update(config_overrides)
     cors = CORS(app, resources={r"/*": {"origins":"*"}})
     api = Api(app)
-
-
-    password_bcrypt = Bcrypt(app)
 
     db.init_app(app)
     db.app = app

--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -4,16 +4,21 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from resources.analytics import Analytics
 from resources.request_for_data import RequestForData
+from resources.register import Register
 from db import db
 from flask_cors import CORS
+from flask_bcrypt import Bcrypt
 
 def create_app(**config_overrides):
     app = Flask(__name__)
-    app.config.from_pyfile('settings.py')
+    app.config.from_pyfile('settings.py') #TODO: change name of database in settings
     app.config.update(config_overrides)
     cors = CORS(app, resources={r"/*": {"origins":"*"}})
     api = Api(app)
-    
+
+
+    password_bcrypt = Bcrypt(app)
+
     db.init_app(app)
     db.app = app
     
@@ -29,10 +34,16 @@ def create_app(**config_overrides):
     from models.sensor_attribute import SensorAttribute 
     from models.theme import Theme, SubTheme
 
+
+    from models.users import Users
+
     db.create_all()
 
     migrate = Migrate(app, db)
     api.add_resource(Analytics, '/analytics')
     api.add_resource(RequestForData, '/data')
+
+
+    api.add_resource(Register, '/register')
 
     return app

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -80,6 +80,7 @@ class Users(db.Model):
         :rtype: string
         """     
         return bcrypt.hashpw(password, bcrypt.gensalt())
+    
     @staticmethod
     def verify_hash(password, hash):
         """A method that adds two things

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -38,6 +38,7 @@ class Users(db.Model):
         return self.json()
 
     def json(self):
+        """ Returns a JSON representation of Users attributes """
         return {
             'id': self.id,
             'fullname': self.firstname,
@@ -47,6 +48,7 @@ class Users(db.Model):
         }
 
     def save(self):
+        """ Adds the current values of the Users fields to SQLAlchemy session but does not write to the database """
         try:
             db.session.add(self)
             db.session.flush()
@@ -55,10 +57,17 @@ class Users(db.Model):
             print(self.fullname, 'User already exists')
 
     def commit(self):
+        """ Writes all updates done via db.session.add() or manual update of the model class fields to the database """
         db.session.commit()
 
     @classmethod
     def find_by_email(cls, email):
+        """ Queries the users table according the email attribute
+            :param email: the email address of the user that is being looked up
+            :type email: string
+            :return: a Users instance where the contained attributes correspond to that of the email provided
+            :rtype: Instance of Users model class 
+        """
         return cls.query.filter_by(email = email).first()
 
     @staticmethod

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -1,11 +1,12 @@
+'''
+Data model class for User credentials 
+'''
+
 import json
 from db import db
 from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 import bcrypt
-
-
-#TODO: add doc string 
 
 class Users(db.Model):
     __tablename__ = 'users'
@@ -15,7 +16,7 @@ class Users(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(400), nullable = False)
     admin = db.Column(db.Boolean)
-    activated = db.Column(db.Boolean)
+    activated = db.Column(db.Boolean) # When a user is added (by the Admin page), their activated field is False. They need to access the /register endpoint to change this field to True
     timestamp = db.Column(db.DateTime)
 
     def __init__(self, fullname, email, password, admin, activated, timestamp=None):
@@ -62,8 +63,24 @@ class Users(db.Model):
 
     @staticmethod
     def generate_hash(password):
+        """A method that adds two things
+
+        :param password: the plaintext user password
+        :type password: UTF8 encoded string
+        :return: a hashed of the password. The password has salt appeneded to it before it is hashed
+        :rtype: string
+        """     
         return bcrypt.hashpw(password, bcrypt.gensalt())
     @staticmethod
     def verify_hash(password, hash):
+        """A method that adds two things
+
+        :param password: the plaintext user password
+        :param hash: the user's hashed password that is stored in the user table
+        :type password: UTF8 encoded string
+        :type password: UTF8 encoded string
+        :return: whether the password, when hashed, corresponds to the password hash stored in the users table
+        :rtype: boolean
+        """     
         return bcrypt.checkpw(password, hash)
 

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -72,19 +72,19 @@ class Users(db.Model):
 
     @staticmethod
     def generate_hash(password):
-        """A method that adds two things
+        """A method that uses the provided password and additional salt in order to generate a hash that is to be stored in the DB
 
         :param password: the plaintext user password
         :type password: UTF8 encoded string
-        :return: a hashed of the password. The password has salt appeneded to it before it is hashed
+        :return: a hash of the password. The password has salt appeneded to it before it is hashed
         :rtype: string
         """     
         return bcrypt.hashpw(password, bcrypt.gensalt())
     
     @staticmethod
     def verify_hash(password, hash):
-        """A method that adds two things
-
+        """A method that verifies whether the password provided matches the corresponding password stored in the database
+        
         :param password: the plaintext user password
         :param hash: the user's hashed password that is stored in the user table
         :type password: UTF8 encoded string

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -2,8 +2,6 @@ import json
 from db import db
 from datetime import datetime
 from sqlalchemy.exc import IntegrityError
-
-from passlib.hash import pbkdf2_sha256 as sha256
 import bcrypt
 
 

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -51,7 +51,7 @@ class Users(db.Model):
             db.session.flush()
         except IntegrityError as ie:
             db.session.rollback()
-            print(self.name, 'User already exists')
+            print(self.fullname, 'User already exists')
 
     def commit(self):
         db.session.commit()

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -1,0 +1,71 @@
+import json
+from db import db
+from datetime import datetime
+from sqlalchemy.exc import IntegrityError
+
+from passlib.hash import pbkdf2_sha256 as sha256
+import bcrypt
+
+
+#TODO: add doc string 
+
+class Users(db.Model):
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    fullname = db.Column(db.String(400), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(400), nullable = False)
+    admin = db.Column(db.Boolean)
+    activated = db.Column(db.Boolean)
+    timestamp = db.Column(db.DateTime)
+
+    def __init__(self, fullname, email, password, admin, activated, timestamp=None):
+        self.fullname = fullname
+        self.email = email
+        self.password = password
+        self.admin = admin
+        self.activated = activated
+
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+
+        self.timestamp = timestamp
+
+    def __repr__(self):
+        return 'Users email is: %s' % self.email
+
+    def __str__(self):
+        return self.json()
+
+    def json(self):
+        return {
+            'id': self.id,
+            'fullname': self.firstname,
+            'email': self.email,
+            'admin': self.admin,
+            'activated': self.activated
+        }
+
+    def save(self):
+        try:
+            db.session.add(self)
+            db.session.flush()
+        except IntegrityError as ie:
+            db.session.rollback()
+            print(self.name, 'User already exists')
+
+    def commit(self):
+        db.session.commit()
+
+    @classmethod
+    def find_by_email(cls, email):
+        return cls.query.filter_by(email = email).first()
+
+    @staticmethod
+    def generate_hash(password):
+        return bcrypt.hashpw(password, bcrypt.gensalt())
+    @staticmethod
+    def verify_hash(password, hash):
+        return bcrypt.checkpw(password, hash)
+

--- a/Analytics/requirements.txt
+++ b/Analytics/requirements.txt
@@ -16,3 +16,4 @@ fbprophet
 holidays==0.9.8
 geojson
 shapely
+pytest

--- a/Analytics/resources/register.py
+++ b/Analytics/resources/register.py
@@ -26,11 +26,9 @@ class Register(Resource):
 		if not current_user:
 			return {'message': 'User {} is not authorised to access Sharing Cities Dashboard'. format(args['email'])}, 403 #t
 
-		# if not Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
-		# 	return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403
+		if not Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
+			return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403
 
-		if not args['password'] == current_user.password:
-			return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403 #t
 
 
 		current_user.activated = True #t

--- a/Analytics/resources/register.py
+++ b/Analytics/resources/register.py
@@ -29,8 +29,6 @@ class Register(Resource):
 		if not Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
 			return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403
 
-
-
 		current_user.activated = True #t
 		current_user.commit()
 		return {'message': '{}\'s account has been registered. Redirect to login'. format(args['email'])}, 201 #t

--- a/Analytics/resources/register.py
+++ b/Analytics/resources/register.py
@@ -3,9 +3,18 @@ from db import db
 from models.users import Users
 from datetime import datetime
 
-#TODO: add doc string 
-
 class Register(Resource):
+	"""API which allows users to activate their Shared Cities Dashboard account
+	Parameters can be passed using a POST request that contains a JSON of the following fields:
+        :param fullname: users fullname
+        :param email: users email address
+        :param password: users password that was sent when they were added on the admin page
+        :type fullname: string
+        :type email: string
+        :type password: string
+        :return: A message that indicates whether a user has been registered. If they have not, the message indicates why not
+        :rtype: JSON
+	"""     
 	parser = reqparse.RequestParser()
 	parser.add_argument('fullname', type=str, store_missing=False) 
 	parser.add_argument('email', type=str, store_missing=False, help = 'This field cannot be blank', required = True)

--- a/Analytics/resources/register.py
+++ b/Analytics/resources/register.py
@@ -1,0 +1,32 @@
+from flask_restful import Resource, reqparse, inputs
+from db import db
+from models.users import Users
+from datetime import datetime
+
+#TODO: add doc string 
+
+class Register(Resource):
+	parser = reqparse.RequestParser()
+	parser.add_argument('fullname', type=str, store_missing=False) 
+	parser.add_argument('email', type=str, store_missing=False, help = 'This field cannot be blank', required = True)
+	parser.add_argument('password', type=str, store_missing=False,  help = 'This field cannot be blank', required = True)
+
+	def post(self):
+		args = self.parser.parse_args()
+		current_user = Users.find_by_email(args['email']) #t
+		if not current_user:
+			return {'message': 'User {} is not authorised to access Sharing Cities Dashboard'. format(args['email'])}, 403 #t
+
+		# TODO: test hasing pswd store NOTE: # current_user.password = Users.generate_hash(current_user.password.encode("utf8")).decode("utf8");current_user.commit()
+
+		# if not User.verify_hash(args['password'], current_user.password):
+		# 	return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403
+
+		if not args['password'] == current_user.password:
+			return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403 #t
+
+
+		current_user.activated = True #t
+		current_user.commit()
+		return {'message': '{}\'s account has been registered. Redirect to login'. format(args['email'])}, 201 #t
+

--- a/Analytics/resources/register.py
+++ b/Analytics/resources/register.py
@@ -17,9 +17,7 @@ class Register(Resource):
 		if not current_user:
 			return {'message': 'User {} is not authorised to access Sharing Cities Dashboard'. format(args['email'])}, 403 #t
 
-		# TODO: test hasing pswd store NOTE: # current_user.password = Users.generate_hash(current_user.password.encode("utf8")).decode("utf8");current_user.commit()
-
-		# if not User.verify_hash(args['password'], current_user.password):
+		# if not Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
 		# 	return {'message': 'The password entered does not correspond to the password sent to {}. Please try again'. format(args['email'])}, 403
 
 		if not args['password'] == current_user.password:

--- a/Analytics/resources/test_register.py
+++ b/Analytics/resources/test_register.py
@@ -5,6 +5,9 @@ from db import db
 
 @pytest.fixture()
 def test_client():
+	""" A fixture that initialises the Flask application, saves the current application context for the duration of a single
+	    test and yields a testing client that can be used for making requests to the endpoints exposed by the application
+	"""
 	test_app = create_app(DATABASE_NAME='test_analysis', TESTING=True)
 	testing_client = test_app.test_client()
 
@@ -17,6 +20,8 @@ def test_client():
 
 @pytest.fixture()
 def dummy_user():
+	""" Creates and saves a user to the database that is to be used for testing purposes """
+	
     not_activated = Users("Not Activated","not_activated@FCC.com",Users.generate_hash("1234".encode("utf8")).decode("utf8"),True,False)
 
     not_activated.save()
@@ -25,6 +30,9 @@ def dummy_user():
     return not_activated
 
 def test_correct_details(test_client, dummy_user):
+	""" Test whether the expected response message and response code is returned when an existing user attempts to activate their account 
+	    with the correct credentials
+	"""
     assert dummy_user.activated == False
     response = test_client.post('/register', data=dict(email=dummy_user.email, password="1234"), follow_redirects=True)
     assert b"account has been registered" in response.data
@@ -34,11 +42,17 @@ def test_correct_details(test_client, dummy_user):
     db.session.commit()
 
 def test_incorrect_email(test_client):
+	""" Test whether an unsuccessful response message and forbidden response code is returned when a user attempts to activate their account 
+	    with the incorrect email
+	"""
     response = test_client.post('/register', data=dict(email="not_a_user@FCC.com", password="1234"), follow_redirects=True)
     assert b"not authorised to access Sharing Cities Dashboard" in response.data
     assert response.status_code == 403
 
 def test_incorrect_password(test_client, dummy_user):
+	""" Test whether an unsuccessful response message and forbidden response code is returned when a user attempts to activate their account 
+	    with the incorrect password
+	"""
     assert dummy_user.activated == False
     response = test_client.post('/register', data=dict(email=dummy_user.email, password="1"), follow_redirects=True)
     assert b"The password entered does not correspond" in response.data
@@ -48,6 +62,7 @@ def test_incorrect_password(test_client, dummy_user):
     db.session.commit()
 
 def test_invalid_inputs(test_client):
+	""" Test whether the /register endpoint provides adequate error responses when invalid input is sent to it """
     response = test_client.post('/register', data=dict(email=None, password=None), follow_redirects=True)
     assert b"This field cannot be blank" in response.data
     assert response.status_code == 400

--- a/Analytics/resources/test_register.py
+++ b/Analytics/resources/test_register.py
@@ -1,0 +1,61 @@
+import pytest 
+from models.users import Users
+from app import create_app
+from db import db
+
+@pytest.fixture()
+def test_client():
+	test_app = create_app(DATABASE_NAME='test_analysis', TESTING=True)
+	testing_client = test_app.test_client()
+
+	test_app_context = test_app.app_context()
+	test_app_context.push()
+
+	yield testing_client
+
+	test_app_context.pop()
+
+@pytest.fixture()
+def dummy_user():
+    not_activated = Users("Not Activated","not_activated@FCC.com",Users.generate_hash("1234".encode("utf8")).decode("utf8"),True,False)
+
+    not_activated.save()
+    not_activated.commit()
+
+    return not_activated
+
+def test_correct_details(test_client, dummy_user):
+    assert dummy_user.activated == False
+    response = test_client.post('/register', data=dict(email=dummy_user.email, password="1234"), follow_redirects=True)
+    assert b"account has been registered" in response.data
+    assert response.status_code == 201
+    assert dummy_user.activated == True
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+def test_incorrect_email(test_client):
+    response = test_client.post('/register', data=dict(email="not_a_user@FCC.com", password="1234"), follow_redirects=True)
+    assert b"not authorised to access Sharing Cities Dashboard" in response.data
+    assert response.status_code == 403
+
+def test_incorrect_password(test_client, dummy_user):
+    assert dummy_user.activated == False
+    response = test_client.post('/register', data=dict(email=dummy_user.email, password="1"), follow_redirects=True)
+    assert b"The password entered does not correspond" in response.data
+    assert response.status_code == 403
+    assert dummy_user.activated == False
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+def test_invalid_inputs(test_client):
+    response = test_client.post('/register', data=dict(email=None, password=None), follow_redirects=True)
+    assert b"This field cannot be blank" in response.data
+    assert response.status_code == 400
+    response = test_client.post('/register', data=dict(email="", password=""), follow_redirects=True)
+    assert b"not authorised to access Sharing Cities Dashboard" in response.data
+    assert response.status_code == 403
+
+
+
+
+


### PR DESCRIPTION
Hi @DannyLee12 

**New Files**
/models/users.py - The user table contain login fields such as the email and password field. The admin field is used to restrict access to certain endpoints. The activated field will be set to false when a user is added to the users table (done by the admin page). This class also has two class methods, *generate_hash* and *verify_hash* which are used when storing and retrieving passwords. 

/resources/register.py - This file contains the logic that is followed when the /register endpoint is called. The user's email and password are sent in a POST request to this endpoint. If email and password authentication is successful, the user's corresponding *activated* field is updated in the database

/resources/test_register.py - contains the relevant tests for the /register endpoint 

**Updates to existing file**

/Analytics/app.py - the register.py resource and users model are both imported. The register endpoint is also exposed at line 43

