### PR TITLE
Ffc 16 login

### DIFF
--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -9,7 +9,6 @@ from resources.refresh_token import TokenRefresh
 from resources.logout import UserLogoutAccess, UserLogoutRefresh
 from db import db
 from flask_cors import CORS
-# from flask_bcrypt import Bcrypt
 
 from flask_jwt_extended import JWTManager
 import datetime
@@ -34,24 +33,30 @@ def create_app(**config_overrides):
     jwt = JWTManager(app)
     @jwt.token_in_blacklist_loader
     def check_if_token_in_blacklist(decrypted_token):
+        ''' Create a function that will be called whenever an access or 
+            refresh token is required by and sent to an endpoint.
+        '''
         jti = decrypted_token['jti']
         return RevokedTokens.is_jti_blacklisted(jti)
 
-    # Create a function that will be called whenever create_access_token
-    # is used. It will take whatever object is passed into the
-    # create_access_token method, and lets us define what custom claims
-    # should be added to the access token.
+
     @jwt.user_claims_loader
     def add_claims_to_access_token(user):
+        ''' Create a function that will be called whenever create_access_token
+            is used. It will take whatever object is passed into the
+            create_access_token method, and lets us define what custom claims
+            should be added to the access token.
+        '''
         return {'admin': user.admin}
 
 
-    # Create a function that will be called whenever create_access_token
-    # is used. It will take whatever object is passed into the
-    # create_access_token method, and lets us define what the identity
-    # of the access token should be.
     @jwt.user_identity_loader
     def user_identity_lookup(user):
+        ''' Create a function that will be called whenever create_access_token
+            is used. It will take whatever object is passed into the
+            create_access_token method, and lets us define what the identity
+            of the access token should be.
+        '''
         return user.email
 
     

--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -26,7 +26,6 @@ def create_app(**config_overrides):
     app.config['JWT_BLACKLIST_ENABLED'] = True
     app.config['JWT_BLACKLIST_TOKEN_CHECKS'] = ['access', 'refresh']
 
-    # password_bcrypt = Bcrypt(app)
     db.init_app(app)
     db.app = app
 

--- a/Analytics/app.py
+++ b/Analytics/app.py
@@ -4,8 +4,16 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from resources.analytics import Analytics
 from resources.request_for_data import RequestForData
+from resources.login import Login, SecretResource
+from resources.refresh_token import TokenRefresh
+from resources.logout import UserLogoutAccess, UserLogoutRefresh
 from db import db
 from flask_cors import CORS
+# from flask_bcrypt import Bcrypt
+
+from flask_jwt_extended import JWTManager
+import datetime
+from models.revoked_tokens import RevokedTokens
 
 def create_app(**config_overrides):
     app = Flask(__name__)
@@ -13,9 +21,39 @@ def create_app(**config_overrides):
     app.config.update(config_overrides)
     cors = CORS(app, resources={r"/*": {"origins":"*"}})
     api = Api(app)
-    
+
+    app.config['JWT_SECRET_KEY'] = 'jwt-secret-string'  #TODO: change before deployement
+    app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(weeks=1) #TODO: change before deployement
+    app.config['JWT_BLACKLIST_ENABLED'] = True
+    app.config['JWT_BLACKLIST_TOKEN_CHECKS'] = ['access', 'refresh']
+
+    # password_bcrypt = Bcrypt(app)
     db.init_app(app)
     db.app = app
+
+    jwt = JWTManager(app)
+    @jwt.token_in_blacklist_loader
+    def check_if_token_in_blacklist(decrypted_token):
+        jti = decrypted_token['jti']
+        return RevokedTokens.is_jti_blacklisted(jti)
+
+    # Create a function that will be called whenever create_access_token
+    # is used. It will take whatever object is passed into the
+    # create_access_token method, and lets us define what custom claims
+    # should be added to the access token.
+    @jwt.user_claims_loader
+    def add_claims_to_access_token(user):
+        return {'admin': user.admin}
+
+
+    # Create a function that will be called whenever create_access_token
+    # is used. It will take whatever object is passed into the
+    # create_access_token method, and lets us define what the identity
+    # of the access token should be.
+    @jwt.user_identity_loader
+    def user_identity_lookup(user):
+        return user.email
+
     
     from models.operation import Operation
     from models.request_analytics import RequestAnalytics
@@ -29,10 +67,20 @@ def create_app(**config_overrides):
     from models.sensor_attribute import SensorAttribute 
     from models.theme import Theme, SubTheme
 
+
+    from models.users import Users
+
     db.create_all()
 
     migrate = Migrate(app, db)
     api.add_resource(Analytics, '/analytics')
     api.add_resource(RequestForData, '/data')
+
+
+    api.add_resource(Login, '/login')
+    api.add_resource(TokenRefresh, '/refreshToken')
+    api.add_resource(UserLogoutAccess, '/revokeAccess')
+    api.add_resource(UserLogoutRefresh, '/revokeRefresh')
+    api.add_resource(SecretResource, '/secret')
 
     return app

--- a/Analytics/models/revoked_tokens.py
+++ b/Analytics/models/revoked_tokens.py
@@ -9,10 +9,17 @@ class RevokedTokens(db.Model):
     jti = db.Column(db.String(200))
     
     def add(self):
+        """ Adds the current values of the Users fields to SQLAlchemy session and then writes the changes to the database """
         db.session.add(self)
         db.session.commit()
     
     @classmethod
     def is_jti_blacklisted(cls, jti):
+        """ Queries the revoked tokens table to determine if the provided JWT ID is presented and hence has been revoked
+            :param jti: the JWT ID that is used when generating access and refresh JWTs
+            :type jti: string
+            :return: Whether the jti is present in the revoked tokens table
+            :rtype: boolean
+        """
         query = cls.query.filter_by(jti = jti).first()
         return bool(query)

--- a/Analytics/models/revoked_tokens.py
+++ b/Analytics/models/revoked_tokens.py
@@ -1,3 +1,6 @@
+'''
+Data model class for storing decrypted access and refresh JWTs that have been revoked 
+'''
 from db import db
 
 class RevokedTokens(db.Model):

--- a/Analytics/models/revoked_tokens.py
+++ b/Analytics/models/revoked_tokens.py
@@ -1,0 +1,15 @@
+from db import db
+
+class RevokedTokens(db.Model):
+    __tablename__ = 'revoked_tokens'
+    id = db.Column(db.Integer, primary_key = True)
+    jti = db.Column(db.String(200))
+    
+    def add(self):
+        db.session.add(self)
+        db.session.commit()
+    
+    @classmethod
+    def is_jti_blacklisted(cls, jti):
+        query = cls.query.filter_by(jti = jti).first()
+        return bool(query)

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -37,6 +37,7 @@ class Users(db.Model):
         return self.json()
 
     def json(self):
+        """ Returns a JSON representation of Users attributes """
         return {
             'id': self.id,
             'fullname': self.firstname,
@@ -46,6 +47,7 @@ class Users(db.Model):
         }
 
     def save(self):
+        """ Adds the current values of the Users fields to SQLAlchemy session but does not write to the database """
         try:
             db.session.add(self)
             db.session.flush()
@@ -54,16 +56,39 @@ class Users(db.Model):
             print(self.fullname, 'User already exists')
 
     def commit(self):
+        """ Writes all updates done via db.session.add() or manual update of the model class fields to the database """
         db.session.commit()
 
     @classmethod
     def find_by_email(cls, email):
+        """ Queries the users table according the email attribute
+            :param email: the email address of the user that is being looked up
+            :type email: string
+            :return: a Users instance where the contained attributes correspond to that of the email provided
+            :rtype: Instance of Users model class 
+        """
         return cls.query.filter_by(email = email).first()
 
     @staticmethod
     def generate_hash(password):
+        """A method that uses the provided password and additional salt in order to generate a hash that is to be stored in the DB
+        :param password: the plaintext user password
+        :type password: UTF8 encoded string
+        :return: a hash of the password. The password has salt appeneded to it before it is hashed
+        :rtype: string
+        """    
         return bcrypt.hashpw(password, bcrypt.gensalt())
+    
     @staticmethod
     def verify_hash(password, hash):
+        """A method that verifies whether the password provided matches the corresponding password stored in the database
+        
+        :param password: the plaintext user password
+        :param hash: the user's hashed password that is stored in the user table
+        :type password: UTF8 encoded string
+        :type password: UTF8 encoded string
+        :return: whether the password, when hashed, corresponds to the password hash stored in the users table
+        :rtype: boolean
+        """
         return bcrypt.checkpw(password, hash)
 

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -1,11 +1,13 @@
+'''
+Data model class for User credentials 
+'''
+
 import json
 from db import db
 from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 import bcrypt
 
-
-#TODO: add doc string 
 
 class Users(db.Model):
     __tablename__ = 'users'

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -1,0 +1,69 @@
+import json
+from db import db
+from datetime import datetime
+from sqlalchemy.exc import IntegrityError
+import bcrypt
+
+
+#TODO: add doc string 
+
+class Users(db.Model):
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    fullname = db.Column(db.String(400), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(400), nullable = False)
+    admin = db.Column(db.Boolean)
+    activated = db.Column(db.Boolean)
+    timestamp = db.Column(db.DateTime)
+
+    def __init__(self, fullname, email, password, admin, activated, timestamp=None):
+        self.fullname = fullname
+        self.email = email
+        self.password = password
+        self.admin = admin
+        self.activated = activated
+
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+
+        self.timestamp = timestamp
+
+    def __repr__(self):
+        return 'Users email is: %s' % self.email
+
+    def __str__(self):
+        return self.json()
+
+    def json(self):
+        return {
+            'id': self.id,
+            'fullname': self.firstname,
+            'email': self.email,
+            'admin': self.admin,
+            'activated': self.activated
+        }
+
+    def save(self):
+        try:
+            db.session.add(self)
+            db.session.flush()
+        except IntegrityError as ie:
+            db.session.rollback()
+            print(self.name, 'User already exists')
+
+    def commit(self):
+        db.session.commit()
+
+    @classmethod
+    def find_by_email(cls, email):
+        return cls.query.filter_by(email = email).first()
+
+    @staticmethod
+    def generate_hash(password):
+        return bcrypt.hashpw(password, bcrypt.gensalt())
+    @staticmethod
+    def verify_hash(password, hash):
+        return bcrypt.checkpw(password, hash)
+

--- a/Analytics/models/users.py
+++ b/Analytics/models/users.py
@@ -51,7 +51,7 @@ class Users(db.Model):
             db.session.flush()
         except IntegrityError as ie:
             db.session.rollback()
-            print(self.name, 'User already exists')
+            print(self.fullname, 'User already exists')
 
     def commit(self):
         db.session.commit()

--- a/Analytics/requirements.txt
+++ b/Analytics/requirements.txt
@@ -16,3 +16,5 @@ fbprophet
 holidays==0.9.8
 geojson
 shapely
+bcrypt
+flask-jwt-extended

--- a/Analytics/requirements.txt
+++ b/Analytics/requirements.txt
@@ -18,3 +18,4 @@ geojson
 shapely
 bcrypt
 flask-jwt-extended
+pytest

--- a/Analytics/resources/login.py
+++ b/Analytics/resources/login.py
@@ -6,9 +6,16 @@ from datetime import datetime
 from flask_jwt_extended import (create_access_token, create_refresh_token, jwt_required, get_jwt_identity,get_jwt_claims)
 from models.users import Users
 
-#TODO: add doc string 
-
 class Login(Resource):
+	"""API that grants users access to the Sharing Cities Dashboard aswell as sends their correpsonding access and refresh JWT
+	   Parameters can be passed using a POST request that contains a JSON with the following fields:
+        :param email: users email address
+        :param password: users password 
+        :type email: string
+        :type password: string
+        :return: A message that indicates whether a user has been logged in. If they have not, the message indicates why not. If they have, their access and refresh JWTs are also returned
+        :rtype: JSON
+	"""
 	parser = reqparse.RequestParser()
 	parser.add_argument('email', type=str, store_missing=False, help = 'This field cannot be blank', required = True)
 	parser.add_argument('password', type=str, store_missing=False, help= 'This field cannot be blank', required = True)
@@ -28,6 +35,10 @@ class Login(Resource):
 			return {'message': 'Incorrect credentials. Please try again'}, 403
 
 class SecretResource(Resource):
+	"""API that is solely used to test the functionality of access JWT
+        :required: A valid access JWT in the Authorization Header in the format - Bearer <JWT>
+        :rtype: JSON
+	"""
 	@jwt_required
 	def get(self):
 		if get_jwt_claims()["admin"]:

--- a/Analytics/resources/login.py
+++ b/Analytics/resources/login.py
@@ -17,19 +17,15 @@ class Login(Resource):
 		args = self.parser.parse_args()
 		current_user = Users.find_by_email(args['email']) #t
 
-		if current_user: 
+		if current_user and Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")): 
 			if current_user.activated:
-				if Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
 					access_token = create_access_token(identity = current_user)
 					refresh_token = create_refresh_token(identity = current_user)
 					return {'message': 'Logged in as {}'.format(current_user.email), 'access_token': access_token, 'refresh_token': refresh_token}, 200
-				else:
-					return {'message': 'Incorrect credentials. Please try again'}, 403
-
 			else:
 				return {'message': 'User {} has not been activated. Please register when redirected to regirstration page'.format(current_user.email)}, 403
 		else:
-			return {'message': 'User {} does not exist. Please try again'.format(args["email"])}, 403
+			return {'message': 'Incorrect credentials. Please try again'}, 403
 
 class SecretResource(Resource):
 	@jwt_required

--- a/Analytics/resources/login.py
+++ b/Analytics/resources/login.py
@@ -1,0 +1,40 @@
+from flask_restful import Resource, reqparse, inputs
+from db import db
+from models.users import Users
+from datetime import datetime
+
+from flask_jwt_extended import (create_access_token, create_refresh_token, jwt_required, get_jwt_identity,get_jwt_claims)
+from models.users import Users
+
+#TODO: add doc string 
+
+class Login(Resource):
+	parser = reqparse.RequestParser()
+	parser.add_argument('email', type=str, store_missing=False, help = 'This field cannot be blank', required = True)
+	parser.add_argument('password', type=str, store_missing=False, help= 'This field cannot be blank', required = True)
+
+	def post(self):
+		args = self.parser.parse_args()
+		current_user = Users.find_by_email(args['email']) #t
+
+		if current_user: 
+			if current_user.activated:
+				if Users.verify_hash(args['password'].encode("utf8"), current_user.password.encode("utf8")):
+					access_token = create_access_token(identity = current_user)
+					refresh_token = create_refresh_token(identity = current_user)
+					return {'message': 'Logged in as {}'.format(current_user.email), 'access_token': access_token, 'refresh_token': refresh_token}, 200
+				else:
+					return {'message': 'Incorrect credentials. Please try again'}, 403
+
+			else:
+				return {'message': 'User {} has not been activated. Please register when redirected to regirstration page'.format(current_user.email)}, 403
+		else:
+			return {'message': 'User {} does not exist. Please try again'.format(args["email"])}, 403
+
+class SecretResource(Resource):
+	@jwt_required
+	def get(self):
+		if get_jwt_claims()["admin"]:
+			return {'answer': 42}, 200
+		else:
+			return {"message": "You do not have the priviledges to view this resource"}, 403

--- a/Analytics/resources/logout.py
+++ b/Analytics/resources/logout.py
@@ -3,6 +3,11 @@ from flask_restful import Resource
 from flask_jwt_extended import  jwt_refresh_token_required, jwt_required, get_jwt_identity, create_access_token, get_raw_jwt
 
 class UserLogoutAccess(Resource):
+    """API that revokes a users access JWT by adding it to the revoked_tokens table
+        :required: A valid access JWT in the Authorization Header in the format - Bearer <JWT>
+        :return: A message that indicates whether the token has been revoked 
+        :rtype: JSON
+    """
     @jwt_required
     def post(self):
         jti = get_raw_jwt()['jti']
@@ -15,6 +20,11 @@ class UserLogoutAccess(Resource):
 
 
 class UserLogoutRefresh(Resource):
+    """API that revokes a users refresh JWT by adding it to the revoked_tokens table
+        :required: A valid refresh JWT in the Authorization Header in the format - Bearer <JWT>
+        :return: A message that indicates whether the token has been revoked 
+        :rtype: JSON
+    """
     @jwt_refresh_token_required
     def post(self):
         jti = get_raw_jwt()['jti']

--- a/Analytics/resources/logout.py
+++ b/Analytics/resources/logout.py
@@ -1,0 +1,26 @@
+from models.revoked_tokens import RevokedTokens
+from flask_restful import Resource
+from flask_jwt_extended import  jwt_refresh_token_required, jwt_required, get_jwt_identity, create_access_token, get_raw_jwt
+
+class UserLogoutAccess(Resource):
+    @jwt_required
+    def post(self):
+        jti = get_raw_jwt()['jti']
+        try:
+            revoked_token = RevokedTokens(jti = jti)
+            revoked_token.add()
+            return {'message': 'Access token has been revoked'}
+        except:
+            return {'message': 'Something went wrong'}, 500
+
+
+class UserLogoutRefresh(Resource):
+    @jwt_refresh_token_required
+    def post(self):
+        jti = get_raw_jwt()['jti']
+        try:
+            revoked_token = RevokedTokens(jti = jti)
+            revoked_token.add()
+            return {'message': 'Refresh token has been revoked'}
+        except:
+            return {'message': 'Something went wrong'}, 500

--- a/Analytics/resources/refresh_token.py
+++ b/Analytics/resources/refresh_token.py
@@ -3,6 +3,11 @@ from flask_jwt_extended import  jwt_refresh_token_required, get_jwt_identity, cr
 from models.users import Users
 
 class TokenRefresh(Resource):
+    """API that creates a new valid access JWT for the requesting user
+        :required: A valid refresh JWT in the Authorization Header in the format - Bearer <JWT>
+        :return: The user's corresponding access JWT
+        :rtype: JSON
+    """  
     @jwt_refresh_token_required
     def post(self):
         current_user = get_jwt_identity() # extracts the users identity from the refresh token

--- a/Analytics/resources/refresh_token.py
+++ b/Analytics/resources/refresh_token.py
@@ -13,4 +13,4 @@ class TokenRefresh(Resource):
         current_user = get_jwt_identity() # extracts the users identity from the refresh token
         current_user = Users.find_by_email(current_user)
         access_token = create_access_token(identity = current_user)
-        return {'access_token': access_token}
+        return {'access_token': access_token}, 200

--- a/Analytics/resources/refresh_token.py
+++ b/Analytics/resources/refresh_token.py
@@ -1,5 +1,6 @@
 from flask_restful import Resource
 from flask_jwt_extended import  jwt_refresh_token_required, get_jwt_identity, create_access_token
+from models.users import Users
 
 class TokenRefresh(Resource):
     @jwt_refresh_token_required

--- a/Analytics/resources/refresh_token.py
+++ b/Analytics/resources/refresh_token.py
@@ -5,5 +5,6 @@ class TokenRefresh(Resource):
     @jwt_refresh_token_required
     def post(self):
         current_user = get_jwt_identity() # extracts the users identity from the refresh token
+        current_user = Users.find_by_email(current_user)
         access_token = create_access_token(identity = current_user)
         return {'access_token': access_token}

--- a/Analytics/resources/refresh_token.py
+++ b/Analytics/resources/refresh_token.py
@@ -1,0 +1,9 @@
+from flask_restful import Resource
+from flask_jwt_extended import  jwt_refresh_token_required, get_jwt_identity, create_access_token
+
+class TokenRefresh(Resource):
+    @jwt_refresh_token_required
+    def post(self):
+        current_user = get_jwt_identity() # extracts the users identity from the refresh token
+        access_token = create_access_token(identity = current_user)
+        return {'access_token': access_token}

--- a/Analytics/resources/test_login_logout.py
+++ b/Analytics/resources/test_login_logout.py
@@ -9,6 +9,10 @@ from sqlalchemy import func
 
 @pytest.fixture()
 def test_client():
+	""" A fixture that initialises the Flask application, saves the current application context for the duration of a single
+	    test and yields a testing client that can be used for making requests to the endpoints exposed by the application
+	"""
+	
 	test_app = create_app(DATABASE_NAME='test_analysis', TESTING=True)
 	testing_client = test_app.test_client()
 
@@ -21,6 +25,8 @@ def test_client():
 
 @pytest.fixture()
 def dummy_user():
+	""" A fixture that creates and saves a user to the database that is to be used for testing purposes """
+	
     user = Users("User","user@FCC.com",Users.generate_hash("wfnbqk".encode("utf8")).decode("utf8"),True,True)
 
     user.save()
@@ -31,6 +37,10 @@ def dummy_user():
 
 
 def test_login_correct_details(test_client, dummy_user):
+	""" Tests whether the correct response message, response code and corresponding access and refresh tokens are
+	    returned when the correct login credentials are supplied 
+	"""
+	
     response = test_client.post('/login', data=dict(email=dummy_user.email, password="wfnbqk"), follow_redirects=True)
     response_json = response.get_json()
     assert "Logged in as" in response_json["message"]
@@ -42,6 +52,9 @@ def test_login_correct_details(test_client, dummy_user):
     db.session.commit()
 
 def test_login_incorrect_details(test_client, dummy_user):
+	""" Tests whether an unsuccessful response message and response code are returned when the incorrect login credentials are supplied 
+	    and ensures that no access or refresh JWT is issued
+	"""
     response = test_client.post('/login', data=dict(email="not_a_user@FCC.com", password="wfnbqk"), follow_redirects=True)
     response_json = response.get_json()
     assert "Incorrect credentials. Please try again" in response_json["message"]
@@ -61,6 +74,9 @@ def test_login_incorrect_details(test_client, dummy_user):
 
 
 def test_revoke_access(test_client,dummy_user):
+	""" Tests whether when a access JWT is revoked that the the token is added to the revoked tokens table and that a user is
+	    is not able to use that token on subsequent requests
+	"""
     response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
     response_login_json = response_login.get_json()
     header = {'Authorization': 'Bearer {}'.format(response_login_json["access_token"])}   
@@ -77,6 +93,9 @@ def test_revoke_access(test_client,dummy_user):
     db.session.commit()
 
 def test_revoke_refresh(test_client,dummy_user):
+	""" Tests whether when a refresh JWT is revoked that the the token is added to the revoked tokens table and that a user is
+	    is not able to use that token to generate new access JWTs
+	"""
     response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
     response_login_json = response_login.get_json()
     header = {'Authorization': 'Bearer {}'.format(response_login_json["refresh_token"])}   
@@ -94,6 +113,7 @@ def test_revoke_refresh(test_client,dummy_user):
 
 
 def test_refresh_token(test_client,dummy_user):
+	""" Tests whether when supplied a refresh JWT, this endpoint provides a new access token that can be used to access other restricted endpoints """
     response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
     response_login_json = response_login.get_json()
     header = {'Authorization': 'Bearer {}'.format(response_login_json["refresh_token"])}   

--- a/Analytics/resources/test_login_logout.py
+++ b/Analytics/resources/test_login_logout.py
@@ -1,0 +1,115 @@
+import pytest 
+from models.users import Users
+from models.revoked_tokens import RevokedTokens
+from app import create_app
+from db import db
+from flask_jwt_extended import create_access_token
+from sqlalchemy import func
+
+
+@pytest.fixture()
+def test_client():
+	test_app = create_app(DATABASE_NAME='test_analysis', TESTING=True)
+	testing_client = test_app.test_client()
+
+	test_app_context = test_app.app_context()
+	test_app_context.push()
+
+	yield testing_client
+
+	test_app_context.pop()
+
+@pytest.fixture()
+def dummy_user():
+    user = Users("User","user@FCC.com",Users.generate_hash("wfnbqk".encode("utf8")).decode("utf8"),True,True)
+
+    user.save()
+    user.commit()
+
+    return user
+
+
+
+def test_login_correct_details(test_client, dummy_user):
+    response = test_client.post('/login', data=dict(email=dummy_user.email, password="wfnbqk"), follow_redirects=True)
+    response_json = response.get_json()
+    assert "Logged in as" in response_json["message"]
+    assert response_json["access_token"] != None
+    assert response_json["refresh_token"] != None
+    assert response.status_code == 200
+
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+def test_login_incorrect_details(test_client, dummy_user):
+    response = test_client.post('/login', data=dict(email="not_a_user@FCC.com", password="wfnbqk"), follow_redirects=True)
+    response_json = response.get_json()
+    assert "Incorrect credentials. Please try again" in response_json["message"]
+    assert "access_token" not in response_json
+    assert "refresh_token" not in response_json
+    assert response.status_code == 403
+
+    response = test_client.post('/login', data=dict(email=dummy_user.email, password="wk"), follow_redirects=True)
+    response_json = response.get_json()
+    assert "Incorrect credentials. Please try again" in response_json["message"]
+    assert "access_token" not in response_json
+    assert "refresh_token" not in response_json
+    assert response.status_code == 403
+
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+
+def test_revoke_access(test_client,dummy_user):
+    response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
+    response_login_json = response_login.get_json()
+    header = {'Authorization': 'Bearer {}'.format(response_login_json["access_token"])}   
+
+    number_of_Entries = db.session.query(func.count(RevokedTokens.id)).scalar()
+    response_revoke_access = test_client.post('/revokeAccess', headers=header, follow_redirects=True)
+    assert b"Access token has been revoked" in response_revoke_access.data
+    assert db.session.query(func.count(RevokedTokens.id)).scalar() > number_of_Entries
+
+    response = test_client.get('/secret', headers=header)
+    assert b"Token has been revoked" in response.data
+
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+def test_revoke_refresh(test_client,dummy_user):
+    response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
+    response_login_json = response_login.get_json()
+    header = {'Authorization': 'Bearer {}'.format(response_login_json["refresh_token"])}   
+
+    number_of_Entries = db.session.query(func.count(RevokedTokens.id)).scalar()
+    response_revoke_refresh = test_client.post('/revokeRefresh', headers=header, follow_redirects=True)
+    assert b"Refresh token has been revoked" in response_revoke_refresh.data
+    assert db.session.query(func.count(RevokedTokens.id)).scalar() > number_of_Entries
+
+    response = test_client.post('/refreshToken', headers=header)
+    assert b"Token has been revoked" in response.data
+
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+
+def test_refresh_token(test_client,dummy_user):
+    response_login = test_client.post('/login', data=dict(email="user@FCC.com", password="wfnbqk"), follow_redirects=True)
+    response_login_json = response_login.get_json()
+    header = {'Authorization': 'Bearer {}'.format(response_login_json["refresh_token"])}   
+
+    response_refresh_token = test_client.post('/refreshToken', headers=header, follow_redirects=True)
+    response_refresh_json = response_refresh_token.get_json()
+    response_refresh_json["access_token"] != None
+
+    header = {'Authorization': 'Bearer {}'.format(response_refresh_json["access_token"])} 
+    response = test_client.get('/secret', headers=header)
+    assert b"42" in response.data
+
+    db.session.delete(dummy_user)
+    db.session.commit()
+
+
+
+
+


### PR DESCRIPTION
**New Files**
/models/users.py - The model for the users table within the databsse
/models/revoked_tokens.py - the model for the revokedTokens table. This table is used to store all access and refresh tokens which have been revoked from users (due to logging out). When either an access or refresh JWT is required, a check is first done to determine whether these tokens are in the revokedTokens table

/resources/login.py - This file contains the logic for when the /login endpoint is called. This endpoint requires the user's email and password to sent in a POST request and if the email and password authentication is successful, along with the user being activated in the user table, an access and refresh JWT is sent to the user which can then be used for subsequent requests. NOTE: the SecretResource class in login.py was used to test whether the access JWT was functioning correctly. 

/resources/refreshToken.py - This file contains the logic for when the /refreshToken endpoint is called. This endpoint requires a user's refresh JWT to be present in the authorization header. This endpoint will be called when a user's access token expires and results in a new access token being generated and sent back to the user.

/resources/logout.py - This file contains the logic for when the /revokeAccess and /revokeRefresh endpoints are called. The /revokeAccess endpoint requires an access JWT and when the endpoint is called, the token is added to the revokedTokens table and therefore it cannot be used in subsequent requests. The /revokeRefresh endpoint functions similarly to /revokeAccess accept that a refresh JWT is required

/resources/test_login_logout.py - contains the relevant tests for the functionality of the /login, /revokeAccess, /revokeRefresh and /refreshToken endpoints

**Updated files** 

/Analytics/app.py - The relevant classes are imported which contain the logic for the /login, /refreshToken, /revokeAccess and /revokeRefresh endpoints, which are then exposed at lines 79 onwards. The flask app's configuration (app.config) is updated to include a JWT secret key, the amount of time it takes for access JWTs to expire and to indicate that tokens will be checked against a blacklisted token table.
An additional claim is added to the JWT at line 46 to include the users admin privileges. This will allow access to certain endpoints to be restricted to only admin users 